### PR TITLE
Handle units as empty string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,34 @@ mod tests {
         let params = OtherStructVariant { null: () };
         let url_params = to_string(&params);
         assert!(url_params.is_ok());
-        assert_eq!(url_params.unwrap(), "null=");
+        assert_eq!(url_params.unwrap(), "");
+    }
+
+    #[test]
+    fn test_nested_unit() {
+        #[derive(Debug, Serialize)]
+        struct StructVariant {
+            string: Option<String>,
+            number: Option<u8>,
+            unit1: (),
+            after_unit: String,
+            unit2: (),
+        }
+
+        let params = StructVariant {
+            string: Some("".to_string()),
+            number: None,
+            unit1: (),
+            after_unit: "hello".to_string(),
+            unit2: (),
+        };
+        let url_params = to_string(&params);
+        assert_eq!(url_params.unwrap(), "string=&after_unit=hello");
+    }
+
+    #[test]
+    fn test_unit() {
+        let url_params = to_string(&());
+        assert_eq!(url_params.unwrap(), "");
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -168,7 +168,7 @@ where
 
     #[inline]
     fn serialize_unit(self) -> Result<()> {
-        self.serialize_seq(Some(0)).map(|_| ())
+        Ok(())
     }
 
     #[inline]


### PR DESCRIPTION
This PR adds the possibility to add units as query parameters and handle it as an empty string.

Example: 

```rust
let url_params = to_string(&());
assert_eq!(url_params.unwrap(), "");
```